### PR TITLE
feat: Implement RenameFS and SyncWriterFile

### DIFF
--- a/file.go
+++ b/file.go
@@ -67,8 +67,8 @@ type gcsWriterFile struct {
 }
 
 var (
-	_ wfs.WriterFile = (*gcsWriterFile)(nil)
-	_ fs.FileInfo    = (*gcsWriterFile)(nil)
+	_ wfs.SyncWriterFile = (*gcsWriterFile)(nil)
+	_ fs.FileInfo        = (*gcsWriterFile)(nil)
 )
 
 func newGcsWriterFile(fsys *GCSFS, obj gcsObject, name string) *gcsWriterFile {
@@ -97,6 +97,12 @@ func (f *gcsWriterFile) Close() error {
 		f.out = nil
 		return err
 	}
+	return nil
+}
+
+// Sync is a no-op. GCS does not support partial flushes; the entire object
+// is written atomically on Close.
+func (f *gcsWriterFile) Sync() error {
 	return nil
 }
 

--- a/fs.go
+++ b/fs.go
@@ -37,6 +37,7 @@ var (
 	_ fs.GlobFS        = (*GCSFS)(nil)
 	_ wfs.WriteFileFS  = (*GCSFS)(nil)
 	_ wfs.RemoveFileFS = (*GCSFS)(nil)
+	_ wfs.RenameFS     = (*GCSFS)(nil)
 )
 
 // New returns a filesystem for the tree of objects rooted at the specified bucket.
@@ -324,6 +325,30 @@ func (fsys *GCSFS) WriteFile(name string, p []byte, mode fs.FileMode) (int, erro
 		return 0, toPathError(err, "WriteFile", name)
 	}
 	return n, nil
+}
+
+// Rename renames oldpath to newpath using GCS server-side copy followed by delete.
+func (fsys *GCSFS) Rename(oldpath, newpath string) error {
+	if !fs.ValidPath(oldpath) {
+		return toPathError(fs.ErrInvalid, "Rename", oldpath)
+	}
+	if !fs.ValidPath(newpath) {
+		return toPathError(fs.ErrInvalid, "Rename", newpath)
+	}
+	c, err := fsys.client()
+	if err != nil {
+		return toPathError(err, "Rename", oldpath)
+	}
+
+	b := c.bucket(fsys.bucket)
+	src := b.object(fsys.key(oldpath))
+	dst := b.object(fsys.key(newpath))
+
+	if err := src.copyTo(fsys.Context(), dst); err != nil {
+		return toPathError(err, "Rename", oldpath)
+	}
+
+	return toPathError(src.delete(fsys.Context()), "Rename", oldpath)
 }
 
 // RemoveFile removes the specified named file.

--- a/fs_test.go
+++ b/fs_test.go
@@ -63,6 +63,20 @@ type fsObject struct {
 	name string
 }
 
+func (o *fsObject) copyTo(ctx context.Context, dst gcsObject) error {
+	dstObj, ok := dst.(*fsObject)
+	if !ok {
+		return errors.New("gcsfs: destination is not a fsObject")
+	}
+
+	data, err := fs.ReadFile(o.fsys, path.Join(o.dir, o.name))
+	if err != nil {
+		return err
+	}
+	_, err = wfs.WriteFile(dstObj.fsys, path.Join(dstObj.dir, dstObj.name), data, fs.ModePerm)
+	return err
+}
+
 func (o *fsObject) newReader(ctx context.Context) (io.ReadCloser, error) {
 	in, err := o.fsys.Open(path.Join(o.dir, o.name))
 	if err != nil {
@@ -279,6 +293,20 @@ func TestWriteFileFS(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := wfstest.TestWriteFileFS(fsys, tmpDir); err != nil {
+		t.Errorf("Error wfstest: %+v", err)
+	}
+}
+
+func TestRenameFS(t *testing.T) {
+	fsys := &GCSFS{
+		bucket: "testdata",
+		c:      &fsClient{fsys: memfs.New()},
+	}
+	tmpDir := "test_rename"
+	if err := wfs.MkdirAll(fsys, tmpDir, fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := wfstest.TestRenameFS(fsys, tmpDir); err != nil {
 		t.Errorf("Error wfstest: %+v", err)
 	}
 }

--- a/gcs.go
+++ b/gcs.go
@@ -2,6 +2,7 @@ package gcsfs
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"cloud.google.com/go/storage"
@@ -21,6 +22,7 @@ type gcsObject interface {
 	attrs(ctx context.Context) (*storage.ObjectAttrs, error)
 	newReader(ctx context.Context) (io.ReadCloser, error)
 	newWriter(ctx context.Context) io.WriteCloser
+	copyTo(ctx context.Context, dst gcsObject) error
 	delete(ctx context.Context) error
 }
 
@@ -64,6 +66,15 @@ func (o *storageObject) newReader(ctx context.Context) (io.ReadCloser, error) {
 
 func (o *storageObject) newWriter(ctx context.Context) io.WriteCloser {
 	return o.obj.NewWriter(ctx)
+}
+
+func (o *storageObject) copyTo(ctx context.Context, dst gcsObject) error {
+	dstObj, ok := dst.(*storageObject)
+	if !ok {
+		return errors.New("gcsfs: destination is not a storageObject")
+	}
+	_, err := dstObj.obj.CopierFrom(o.obj).Run(ctx)
+	return err
 }
 
 func (o *storageObject) attrs(ctx context.Context) (*storage.ObjectAttrs, error) {


### PR DESCRIPTION
## Summary

- Add `Rename(oldpath, newpath)` via GCS server-side copy (`CopierFrom`) + delete, implementing `wfs.RenameFS`.
- Add no-op `Sync()` to `gcsWriterFile`, implementing `wfs.SyncWriterFile`.
- Add `TestRenameFS` using `wfstest.TestRenameFS`.

## Test plan

- [x] `go test -race ./...` passes locally
- [x] `golangci-lint run ./...` reports 0 issues
- [x] CI workflows pass on GitHub