### PR TITLE
fix: Handle Open/Stat for root directory on real GCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ if err := fstest.TestFS(fsys, "<your-expected>"); err != nil {
 
 ## Integration tests
 
+Integration tests run against a real GCS bucket and require
+[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials):
+
+```sh
+gcloud auth application-default login
+```
+
+Then run:
+
 ```sh
 FSTEST_BUCKET="<your-bucket>" \
 FSTEST_EXPECTED="<your-expected>" \

--- a/fs.go
+++ b/fs.go
@@ -135,6 +135,10 @@ func (fsys *GCSFS) openFile(name string) (*gcsFile, error) {
 
 // Open opens the named file or directory.
 func (fsys *GCSFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		return newGcsDir(fsys, ".").open(fsys.DirOpenBufferSize)
+	}
+
 	f, err := fsys.openFile(name)
 	if err != nil && isNotExist(err) {
 		return newGcsDir(fsys, name).open(fsys.DirOpenBufferSize)
@@ -145,6 +149,10 @@ func (fsys *GCSFS) Open(name string) (fs.File, error) {
 // Stat returns a FileInfo describing the file. If there is an error, it should be
 // of type *PathError.
 func (fsys *GCSFS) Stat(name string) (fs.FileInfo, error) {
+	if name == "." {
+		return newGcsDir(fsys, ".").open(1)
+	}
+
 	f, err := fsys.openFile(name)
 	if err != nil && isNotExist(err) {
 		return newGcsDir(fsys, name).open(1)

--- a/fs_integ_test.go
+++ b/fs_integ_test.go
@@ -12,7 +12,6 @@ import (
 	"testing/fstest"
 
 	"cloud.google.com/go/storage"
-	"google.golang.org/api/option"
 )
 
 func TestFSIntegration(t *testing.T) {
@@ -23,7 +22,7 @@ func TestFSIntegration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx, option.WithoutAuthentication())
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- `Open(".")` and `Stat(".")` sent `"."` as an object name to GCS, which rejects it as invalid. The error was not recognized as "not exist", so the directory fallback was never reached. Skip the file lookup for `"."` and go directly to the directory path.
- Remove `option.WithoutAuthentication()` from the integration test so it works with private buckets via ADC.
- Document the ADC requirement in README.

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] CI workflows pass on GitHub
- [x] Integration test passes with `gcloud auth application-default login` + real bucket